### PR TITLE
Paging review

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,9 +122,7 @@ gdb-kernel-debug: image
 		-ex 'layout reg' \
 		-ex 'break _start' \
 		-ex 'break *0x7c00' \
-		-ex 'b	src/kernel/cpu/mmu/VMM.c:60' \
-		-ex 'b	src/kernel/cpu/mmu/VMM.c:79' \
-		-ex 'b	src/kernel/cpu/mmu/VMM.c:92' \
+		-ex 'b	src/kernel/cpu/mmu/VMM.c:96' \
 		-ex 'b	src/kernel/cpu/mmu/VMM.c:113' \
 		-ex 'b	src/kernel/cpu/mmu/VMM.c:117' \
 		-ex 'set disassembly-flavor intel' \

--- a/src/kernel/cpu/mmu/VMM.c
+++ b/src/kernel/cpu/mmu/VMM.c
@@ -75,7 +75,8 @@ bool VMM_init()
         // page->frame = (i << 12); // * PAGE_SIZE (4096) , physical addr
 
         page_table->entries[i] = (PTE_t){((i << 12) | 3)};
-
+        // *page = (PTE_t){((i << 12) | 3)};
+       
     }
 
 //     for (int i = 0, frame = 0x100000, virt = 0xc0000000; i<PAGE_TABLE_ENTRIES; i++, frame+=PAGE_SIZE, virt+=PAGE_SIZE)
@@ -86,12 +87,13 @@ bool VMM_init()
 //         page_table->entries[PAGE_TABLE_INDEX(virt)] = page;
 //    }
 
-    // PDE_t* entry = &_kernel_directory->entries[0];
-    // entry->p = 1;
-    // entry->rw = 1;
-    // entry->page_table = (uint32_t)page_table;
-    _kernel_directory->entries[0] = (PDE_t)(page_table) | 3;
-
+    PDE_t* entry = &_kernel_directory->entries[0];
+    entry->p = 1;
+    entry->rw = 1;
+    entry->page_table = ((uint32_t)page_table) >> 12;
+    // _kernel_directory->entries[0] = ((PDE_t)page_table) | 3;
+    int t =( (uint32_t)page_table)|3;
+    t=t;
     // PDE_t* entry2 = &page_dir->entries[PAGE_DIR_INDEX(0)];
     // entry2->p = 1;
     // entry2->rw = 1;

--- a/src/kernel/cpu/mmu/VMM.c
+++ b/src/kernel/cpu/mmu/VMM.c
@@ -15,11 +15,6 @@
 static page_directory_t* _kernel_directory  = NULL;
 static page_directory_t* _current_directory = NULL;
 
-//////// TEST ///////////
-// uint32_t* page_directory;
-// uint32_t* first_page_table;
-
-
 void page_fault_handler(ISR_registers_t regs)
 {
     // A page fault has occurred.
@@ -55,14 +50,12 @@ bool VMM_init()
     _kernel_directory = PMM_malloc(sizeof(page_directory_t));
     
     page_table_t*       page_table  = PMM_malloc(sizeof(page_table_t));
-    // page_table_t*       page_table2 = PMM_malloc(sizeof(page_table_t));
 
-    if(page_table == NULL /*|| page_table2 == NULL */|| _kernel_directory == NULL)
+    if(page_table == NULL || _kernel_directory == NULL)
         return false;
 
     memset(_kernel_directory, 0, sizeof(page_directory_t));
     memset(page_table, 0, sizeof(page_table_t));
-    // memset(page_table2, 0, sizeof(page_table_t));
  
     // TODO: forgot to allocate some space for the stack ... just inside the linker at the moment
 
@@ -79,68 +72,17 @@ bool VMM_init()
        
     }
 
-//     for (int i = 0, frame = 0x100000, virt = 0xc0000000; i<PAGE_TABLE_ENTRIES; i++, frame+=PAGE_SIZE, virt+=PAGE_SIZE)
-//     {
-//         PTE_t page = {0};
-//         page.p = 1;
-//         page.frame = frame;
-//         page_table->entries[PAGE_TABLE_INDEX(virt)] = page;
-//    }
-
-    PDE_t* entry = &_kernel_directory->entries[0];
-    entry->p = 1;
-    entry->rw = 1;
-    entry->page_table = ((uint32_t)page_table) >> 12;
-    // _kernel_directory->entries[0] = ((PDE_t)page_table) | 3;
-    int t =( (uint32_t)page_table)|3;
-    t=t;
-    // PDE_t* entry2 = &page_dir->entries[PAGE_DIR_INDEX(0)];
-    // entry2->p = 1;
-    // entry2->rw = 1;
-    // // entry2->page_table = (uint32_t)page_table2;
-    // entry2->page_table = (uint32_t) page_table;
+    // PDE_t* entry = &_kernel_directory->entries[0];
+    // entry->p = 1;
+    // entry->rw = 1;
+    // entry->page_table = ((uint32_t)page_table) >> 12;
+    _kernel_directory->entries[0] = ((PDE_t)page_table) | 3;
 
     ISR_register_interrupt_handler(INT_Page_Fault, page_fault_handler);
     VMM_switch_page_directory(_kernel_directory);
     VMM_enable_paging();
 
     return true;
-
- ///// TEST //////
-// page_directory = PMM_malloc(1024);
-// memset(page_directory, 0,1024);
-// first_page_table = PMM_malloc(1024);
-// memset(first_page_table, 0,1024);
-
-
-// for(int i = 0; i < 1024; i++)
-// {
-//     // This sets the following flags to the pages:
-//     //   Supervisor: Only kernel-mode can access them
-//     //   Write Enabled: It can be both read from and written to
-//     //   Not Present: The page table is not present
-//     page_directory[i] = 0x00000002;
-// }
-
-// // holds the physical address where we want to start mapping these pages to.
-// // in this case, we want to map these pages to the very beginning of memory.
- 
-// //we will fill all 1024 entries in the table, mapping 4 megabytes
-// for(unsigned int i = 0; i < 1024; i++)
-// {
-//     // As the address is page aligned, it will always leave 12 bits zeroed.
-//     // Those bits are used by the attributes ;)
-//     first_page_table[i] = (i * 0x1000) | 3; // attributes: supervisor level, read/write, present.
-// }
-
-// // attributes: supervisor level, read/write, present
-// page_directory[0] = ((unsigned int)first_page_table) | 3;
-//  __asm__ volatile("mov cr3, %0": : "a"(page_directory));
-
-// VMM_enable_paging();
-
-// return true;
-
 }
 
 bool VMM_switch_page_directory(page_directory_t* page_directory)

--- a/src/kernel/cpu/mmu/VMM.c
+++ b/src/kernel/cpu/mmu/VMM.c
@@ -70,11 +70,11 @@ bool VMM_init()
     for (uint32_t i = 0; i < PAGE_TABLE_ENTRIES; i++)
     {
         // PTE_t* page = &page_table->entries[i];
-        // page->p = 1;
-        // page->rw =1;
-        // page->frame = (i * 0x1000); // * PAGE_SIZE (4096) , physical addr
+        // page->p     = 1;
+        // page->rw    = 1;
+        // page->frame = (i << 12); // * PAGE_SIZE (4096) , physical addr
 
-        page_table->entries[i] = (i * 0x1000) | 3;
+        page_table->entries[i] = (PTE_t){((i << 12) | 3)};
 
     }
 
@@ -89,7 +89,6 @@ bool VMM_init()
     // PDE_t* entry = &_kernel_directory->entries[0];
     // entry->p = 1;
     // entry->rw = 1;
-    // // entry->us = 1;
     // entry->page_table = (uint32_t)page_table;
     _kernel_directory->entries[0] = (PDE_t)(page_table) | 3;
 

--- a/src/kernel/cpu/mmu/VMM.c
+++ b/src/kernel/cpu/mmu/VMM.c
@@ -62,21 +62,19 @@ bool VMM_init()
     // first 1MB
     for (uint32_t i = 0; i < PAGE_TABLE_ENTRIES; i++)
     {
-        // PTE_t* page = &page_table->entries[i];
-        // page->p     = 1;
-        // page->rw    = 1;
-        // page->frame = (i << 12); // * PAGE_SIZE (4096) , physical addr
+        PTE_t* page = &page_table->entries[i];
+        page->p     = 1;
+        page->rw    = 1;
+        page->frame = i; // * PAGE_SIZE (4096) , physical addr
 
-        page_table->entries[i] = (PTE_t){((i << 12) | 3)};
-        // *page = (PTE_t){((i << 12) | 3)};
-       
+        // page_table->entries[i] = (PTE_t){((i << 12) | 3)};
     }
 
-    // PDE_t* entry = &_kernel_directory->entries[0];
-    // entry->p = 1;
-    // entry->rw = 1;
-    // entry->page_table = ((uint32_t)page_table) >> 12;
-    _kernel_directory->entries[0] = ((PDE_t)page_table) | 3;
+    PDE_t* entry = &_kernel_directory->entries[0];
+    entry->p = 1;
+    entry->rw = 1;
+    entry->page_table = ((uint32_t)page_table >> 12);
+    // _kernel_directory->entries[0] = ((PDE_t)page_table) | 3;
 
     ISR_register_interrupt_handler(INT_Page_Fault, page_fault_handler);
     VMM_switch_page_directory(_kernel_directory);

--- a/src/kernel/cpu/mmu/VMM.h
+++ b/src/kernel/cpu/mmu/VMM.h
@@ -22,21 +22,21 @@
 #define PAGE_DIR_ENTRIES    1024
 #define PAGE_TABLE_ENTRIES  1024
 
-typedef struct PDE_t
-{
-    uint32_t p          :   1;  // present bit to reference a page table
-    uint32_t rw         :   1;  // if 0 write may not be allowed
-    uint32_t us         :   1;  // if 0 User mode not allowed to access the memory region.
-    uint32_t pwt        :   1;  // Page level Write Through
-    uint32_t pcd        :   1;  // Page level Cache Disabled
-    uint32_t a          :   1;  // Accessed?
-    uint32_t ign        :   1;  // ignored
-    uint32_t zero       :   1;  // If CR4.PSE = 1, must be 0 (4KB pages)
-    uint32_t ign2       :   4;  // ignored
-    uint32_t page_table :   20; // Physical address of 4-KByte aligned page table referenced by this entry
+// typedef struct PDE_t
+// {
+//     uint32_t p          :   1;  // present bit to reference a page table
+//     uint32_t rw         :   1;  // if 0 write may not be allowed
+//     uint32_t us         :   1;  // if 0 User mode not allowed to access the memory region.
+//     uint32_t pwt        :   1;  // Page level Write Through
+//     uint32_t pcd        :   1;  // Page level Cache Disabled
+//     uint32_t a          :   1;  // Accessed?
+//     uint32_t ign        :   1;  // ignored
+//     uint32_t zero       :   1;  // If CR4.PSE = 1, must be 0 (4KB pages)
+//     uint32_t ign2       :   4;  // ignored
+//     uint32_t page_table :   20; // Physical address of 4-KByte aligned page table referenced by this entry
 
-} __attribute__((packed)) PDE_t;
-_Static_assert(sizeof(PDE_t) == sizeof(uint32_t));
+// } __attribute__((packed)) PDE_t;
+// _Static_assert(sizeof(PDE_t) == sizeof(uint32_t));
 
 // typedef struct PTE_t
 // {
@@ -54,7 +54,7 @@ _Static_assert(sizeof(PDE_t) == sizeof(uint32_t));
 // } __attribute__((aligned(4))) PTE_t;
 // _Static_assert(sizeof(PTE_t) == sizeof(uint32_t));
 
-// typedef uint32_t PDE_t;
+typedef uint32_t PDE_t;
 typedef uint32_t PTE_t;
 
 typedef struct page_table_t

--- a/src/kernel/cpu/mmu/VMM.h
+++ b/src/kernel/cpu/mmu/VMM.h
@@ -22,22 +22,21 @@
 #define PAGE_DIR_ENTRIES    1024
 #define PAGE_TABLE_ENTRIES  1024
 
-#pragma pack(push, 1)
-// typedef struct PDE_t
-// {
-//     uint32_t p          :   1;  // present bit to reference a page table
-//     uint32_t rw         :   1;  // if 0 write may not be allowed
-//     uint32_t us         :   1;  // if 0 User mode not allowed to access the memory region.
-//     uint32_t pwt        :   1;  // Page level Write Through
-//     uint32_t pcd        :   1;  // Page level Cache Disabled
-//     uint32_t a          :   1;  // Accessed?
-//     uint32_t ign        :   1;  // ignored
-//     uint32_t zero       :   1;  // If CR4.PSE = 1, must be 0 (4KB pages)
-//     uint32_t ign2       :   4;  // ignored
-//     uint32_t page_table :   20; // Physical address of 4-KByte aligned page table referenced by this entry
+typedef struct PDE_t
+{
+    uint32_t p          :   1;  // present bit to reference a page table
+    uint32_t rw         :   1;  // if 0 write may not be allowed
+    uint32_t us         :   1;  // if 0 User mode not allowed to access the memory region.
+    uint32_t pwt        :   1;  // Page level Write Through
+    uint32_t pcd        :   1;  // Page level Cache Disabled
+    uint32_t a          :   1;  // Accessed?
+    uint32_t ign        :   1;  // ignored
+    uint32_t zero       :   1;  // If CR4.PSE = 1, must be 0 (4KB pages)
+    uint32_t ign2       :   4;  // ignored
+    uint32_t page_table :   20; // Physical address of 4-KByte aligned page table referenced by this entry
 
-// } __attribute__((packed)) PDE_t;
-// _Static_assert(sizeof(PDE_t) == sizeof(uint32_t));
+} __attribute__((packed)) PDE_t;
+_Static_assert(sizeof(PDE_t) == sizeof(uint32_t));
 
 // typedef struct PTE_t
 // {
@@ -52,11 +51,10 @@
 //     uint32_t g          : 1;     // Global; if CR3.PGE=1 determines wheter the translation is global. Otherwise ignored
 //     uint32_t ignored    : 3;     // ignored
 //     uint32_t frame      : 20;    // Physical address of 4KB page referenced by this entry.
-// } __attribute__((packed)) PTE_t;
+// } __attribute__((aligned(4))) PTE_t;
 // _Static_assert(sizeof(PTE_t) == sizeof(uint32_t));
-#pragma pack(pop)
 
-typedef uint32_t PDE_t;
+// typedef uint32_t PDE_t;
 typedef uint32_t PTE_t;
 
 typedef struct page_table_t

--- a/src/kernel/cpu/mmu/VMM.h
+++ b/src/kernel/cpu/mmu/VMM.h
@@ -22,40 +22,40 @@
 #define PAGE_DIR_ENTRIES    1024
 #define PAGE_TABLE_ENTRIES  1024
 
-// typedef struct PDE_t
-// {
-//     uint32_t p          :   1;  // present bit to reference a page table
-//     uint32_t rw         :   1;  // if 0 write may not be allowed
-//     uint32_t us         :   1;  // if 0 User mode not allowed to access the memory region.
-//     uint32_t pwt        :   1;  // Page level Write Through
-//     uint32_t pcd        :   1;  // Page level Cache Disabled
-//     uint32_t a          :   1;  // Accessed?
-//     uint32_t ign        :   1;  // ignored
-//     uint32_t zero       :   1;  // If CR4.PSE = 1, must be 0 (4KB pages)
-//     uint32_t ign2       :   4;  // ignored
-//     uint32_t page_table :   20; // Physical address of 4-KByte aligned page table referenced by this entry
+typedef struct PDE_t
+{
+    uint32_t p          :   1;  // present bit to reference a page table
+    uint32_t rw         :   1;  // if 0 write may not be allowed
+    uint32_t us         :   1;  // if 0 User mode not allowed to access the memory region.
+    uint32_t pwt        :   1;  // Page level Write Through
+    uint32_t pcd        :   1;  // Page level Cache Disabled
+    uint32_t a          :   1;  // Accessed?
+    uint32_t ign        :   1;  // ignored
+    uint32_t zero       :   1;  // If CR4.PSE = 1, must be 0 (4KB pages)
+    uint32_t ign2       :   4;  // ignored
+    uint32_t page_table :   20; // Physical address of 4-KByte aligned page table referenced by this entry
 
-// } __attribute__((packed)) PDE_t;
-// _Static_assert(sizeof(PDE_t) == sizeof(uint32_t));
+} __attribute__((packed)) PDE_t;
+_Static_assert(sizeof(PDE_t) == sizeof(uint32_t));
 
-// typedef struct PTE_t
-// {
-//     uint32_t p          : 1;     // Present bit (must be 1, 0 otheerwise OS can use it for swap)
-//     uint32_t rw         : 1;     // if 0 write may not be allowed
-//     uint32_t us         : 1;     // if 0 User mode not allowed to access the page referenced by this entry.
-//     uint32_t pwt        : 1;     // Page level Write Through
-//     uint32_t pcd        : 1;     // Page level Cache Disabled
-//     uint32_t a          : 1;     // Accessed?
-//     uint32_t d          : 1;     // Dirty?
-//     uint32_t pat        : 1;     // if PAT supported, otherwise reseverd (must be 0)
-//     uint32_t g          : 1;     // Global; if CR3.PGE=1 determines wheter the translation is global. Otherwise ignored
-//     uint32_t ignored    : 3;     // ignored
-//     uint32_t frame      : 20;    // Physical address of 4KB page referenced by this entry.
-// } __attribute__((aligned(4))) PTE_t;
-// _Static_assert(sizeof(PTE_t) == sizeof(uint32_t));
+typedef struct PTE_t
+{
+    uint32_t p          : 1;     // Present bit (must be 1, 0 otheerwise OS can use it for swap)
+    uint32_t rw         : 1;     // if 0 write may not be allowed
+    uint32_t us         : 1;     // if 0 User mode not allowed to access the page referenced by this entry.
+    uint32_t pwt        : 1;     // Page level Write Through
+    uint32_t pcd        : 1;     // Page level Cache Disabled
+    uint32_t a          : 1;     // Accessed?
+    uint32_t d          : 1;     // Dirty?
+    uint32_t pat        : 1;     // if PAT supported, otherwise reseverd (must be 0)
+    uint32_t g          : 1;     // Global; if CR3.PGE=1 determines wheter the translation is global. Otherwise ignored
+    uint32_t ignored    : 3;     // ignored
+    uint32_t frame      : 20;    // Physical address of 4KB page referenced by this entry.
+} __attribute__((aligned(4))) PTE_t;
+_Static_assert(sizeof(PTE_t) == sizeof(uint32_t));
 
-typedef uint32_t PDE_t;
-typedef uint32_t PTE_t;
+// typedef uint32_t PDE_t;
+// typedef uint32_t PTE_t;
 
 typedef struct page_table_t
 {

--- a/src/kernel/cpu/mmu/VMM.h
+++ b/src/kernel/cpu/mmu/VMM.h
@@ -35,7 +35,7 @@ typedef struct PDE_t
     uint32_t ign2       :   4;  // ignored
     uint32_t page_table :   20; // Physical address of 4-KByte aligned page table referenced by this entry
 
-} __attribute__((packed)) PDE_t;
+} __attribute__((aligned(4))) PDE_t;
 _Static_assert(sizeof(PDE_t) == sizeof(uint32_t));
 
 typedef struct PTE_t


### PR DESCRIPTION
- init
- update Makefile
- update linker.ld
- [WIP] paging
- ISR/IRQ Refactor (#9)
- [wip] paging
- ISR passing dummy 0 err code when not available to interrupt handler (#10)
- update makefile floppy target
- update makefile boot2 targer
- code rev
- add a basic sleep function
- keyboard files
- kernel.ld
- add kernel size symbol in linker for self-relocating
- code rev
- [wip] paging
- [WIP] paging
- bitset
- [WIP] PMM, console init, paging, code rev
- CON_printf
- fix itoa to utoa
- [WIP] PMM
- [WIP] PMM
- Fix PMM init
- PMM
- code rev
- code rev
- [WIP] VMM, need to fix the stack and allocate with PMM
- [WIP] hijacked kernel stack starting location
- [WIP] PMM kernel deinit fix
- [WIP] PMM kernel deinit fix
- WIP
- [WIP] paging...
- [wip] paging
- [TEST] paging working in a simplified manner. something in my struct is not ok then.
- [WIP|Paging] PMM_malloc ok
- paging working using uint32_t
- init
- paging, better just use uint32_t instead of struct
- working with uint32_t
- working with struct
