### PR TITLE
divide error

### DIFF
--- a/BIOS_bootloader/src/bios/PrintNumber.inc
+++ b/BIOS_bootloader/src/bios/PrintNumber.inc
@@ -1,7 +1,12 @@
 # Print a number stored in AX
 # It uses the stack to store the digits
 # it will then pop from the stack to display the number correctly as a string.
-# It usse the PrintString function.
+# ***********************************
+
+# the code can generate DIV ERROR, (>=2560 for e.g)
+# but with interrupts disable should keep going and returning a wrong result (?)
+
+# Upgrade to div by 16 bits instead of 8 bits
 
 .ifndef PrintNumber
 .include "bios/PrintChar.inc"
@@ -13,19 +18,18 @@ PrintNumber:
   push bx
 
   xor cx, cx # storing number of digits
-  mov dl, 10 # divides by 10
+  mov bx, 10 # divides by 10
 PrintNumber_loop:
-  div dl     # AL = Quotient, AH = Remainder
-  # TODO: div error handling
-  push ax
+  xor dx, dx # number high part
+  div bx    # DX:AX / 10 => AX = Quotient, DX= Remainder
+  push dx
   inc cx
   and ax, 0xFF
   jnz PrintNumber_loop
 PrintNumber_loop_print:
   # 1 digits is always guaranteed: 0
   pop ax
-  mov al, ah
-  add al, '0'
+  add ax, '0'
   call PrintChar
   loop PrintNumber_loop_print
 
@@ -35,6 +39,8 @@ PrintNumber_loop_print:
   pop cx
   ret
 .endfunc
+
+# 2560 / 10, 256, 0 (#DE exception 256 greater than 255 can fit a 8 bit register)
 
 # 1000 / 10, 100, 0
 # 100 / 10, 10, 0

--- a/BIOS_bootloader/src/bios/PrintNumber.inc
+++ b/BIOS_bootloader/src/bios/PrintNumber.inc
@@ -3,10 +3,8 @@
 # it will then pop from the stack to display the number correctly as a string.
 # ***********************************
 
-# the code can generate DIV ERROR, (>=2560 for e.g)
-# but with interrupts disable should keep going and returning a wrong result (?)
-
-# Upgrade to div by 16 bits instead of 8 bits
+# Upgraded to div by 16 bits instead of 8 bits, using 16 bits input number.
+# this should guarantee no #DE exception (apart div by zero)
 
 .ifndef PrintNumber
 .include "bios/PrintChar.inc"
@@ -20,11 +18,10 @@ PrintNumber:
   xor cx, cx # storing number of digits
   mov bx, 10 # divides by 10
 PrintNumber_loop:
-  xor dx, dx # number high part
-  div bx    # DX:AX / 10 => AX = Quotient, DX= Remainder
+  xor dx, dx    # number high part
+  div bx        # DX:AX / 10 => AX = Quotient, DX= Remainder
   push dx
   inc cx
-  and ax, 0xFF
   jnz PrintNumber_loop
 PrintNumber_loop_print:
   # 1 digits is always guaranteed: 0

--- a/kernel/src/arch/x86/PIT.c
+++ b/kernel/src/arch/x86/PIT.c
@@ -46,7 +46,7 @@ static void timer_callback(ISR_registers_t r)
     char buf[11]; // 4294967295
 
     _ticks++;
-    itoa10(_ticks, buf);
+    itoa(_ticks, buf, 10);
     VGA_WriteString(0,24, buf, VGA_COLOR_BRIGHT_GREEN);
 }
 
@@ -86,5 +86,7 @@ void sleep(const unsigned int ticks_)
     unsigned long eticks;
 
     eticks = _ticks + ticks_;
-    while(_ticks < eticks);
+    while(_ticks < eticks) {
+        __asm__("hlt");
+    }
 }

--- a/kernel/src/arch/x86/lib/stdlib.S
+++ b/kernel/src/arch/x86/lib/stdlib.S
@@ -1,86 +1,89 @@
 /* -*-Asm-*- */
 /* x86 specific code */
 
-.code32
-.intel_syntax noprefix
-.text
+// 2560 throws divide error: 2560 % 10 = 256 (greater than 255)
+// requires to use bigger registers and handling the INT0 exception
 
-#include <arch/x86/defs/asm.h>
+# .code32
+# .intel_syntax noprefix
+# .text
 
-ASM_BEGIN(itoa10)
-  # return value in eax
-  push ebp
-  push ebx
-  mov ebp, esp
-  # 12, because 4 for ebp, 4 ebx and other 4 for EIP due to the call/ret
-  mov eax, [ebp + 12]   # value
-  xor ecx,ecx           # string size
-  mov ebx, 10           # base
-  xor edx,edx
-itoa10_div_loop:
-  div bl                # AL := Quotient, AH := Remainder
-  push ax               # the remainder is the digit
-  inc ecx
-  and ax, 0xFF
-  jnz itoa10_div_loop
+# #include <arch/x86/defs/asm.h>
 
-  mov ebx, [ebp + 12+4]   # str ptr
-  mov edi, ebx
+# ASM_BEGIN(itoa10)
+#   # return value in eax
+#   push ebp
+#   push ebx
+#   mov ebp, esp
+#   # 12, because 4 for ebp, 4 ebx and other 4 for EIP due to the call/ret
+#   mov eax, [ebp + 12]   # value
+#   xor ecx,ecx           # string size
+#   mov ebx, 10           # base
+#   xor edx,edx
+# itoa10_div_loop:
+#   div bl                # AL := Quotient, AH := Remainder
+#   push ax               # the remainder is the digit
+#   inc ecx
+#   and ax, 0xFF
+#   jnz itoa10_div_loop
 
-itoa10_store_loop:
-  # 1 digits is always guaranteed: 0
-  pop ax
-  mov al, ah
-  add al, '0'
-  stosb
-  loop itoa10_store_loop
-  xor al,al
-  stosb     # null terminated string
-  mov eax, ebx
+#   mov ebx, [ebp + 12+4]   # str ptr
+#   mov edi, ebx
 
-  pop ebx
-  pop ebp
-  ret
-ASM_END(itoa10)
+# itoa10_store_loop:
+#   # 1 digits is always guaranteed: 0
+#   pop ax
+#   mov al, ah
+#   add al, '0'
+#   stosb
+#   loop itoa10_store_loop
+#   xor al,al
+#   stosb     # null terminated string
+#   mov eax, ebx
 
-ASM_BEGIN(itoa16)
-itoa16:
-  # return value in eax
-  push ebp
-  push ebx
-  mov ebp, esp
-  # 12, because 4 for ebp, 4 ebx and other 4 for EIP due to the call/ret
-  mov eax, [ebp + 12]   # value
-  xor ecx,ecx           # string size
-  mov ebx, 16           # base
-  xor edx,edx
-itoa16_div_loop:
-  div bl                # AL := Quotient, AH := Remainder
-  push ax               # the remainder is the digit
-  inc ecx
-  and ax, 0xFF
-  jnz itoa16_div_loop
+#   pop ebx
+#   pop ebp
+#   ret
+# ASM_END(itoa10)
 
-  mov ebx, [ebp + 12+4]   # str ptr
-  mov edi, ebx
+# ASM_BEGIN(itoa16)
+# itoa16:
+#   # return value in eax
+#   push ebp
+#   push ebx
+#   mov ebp, esp
+#   # 12, because 4 for ebp, 4 ebx and other 4 for EIP due to the call/ret
+#   mov eax, [ebp + 12]   # value
+#   xor ecx,ecx           # string size
+#   mov ebx, 16           # base
+#   xor edx,edx
+# itoa16_div_loop:
+#   div bl                # AL := Quotient, AH := Remainder
+#   push ax               # the remainder is the digit
+#   inc ecx
+#   and ax, 0xFF
+#   jnz itoa16_div_loop
 
-itoa16_store_loop:
-  # 1 digits is always guaranteed: 0
-  pop ax
-  mov al, ah
-  cmp al, 9
-  jg itoa16_store_loop_alpha
-  add al, '0'
-  jmp itao16_store_loop_stosb
-itoa16_store_loop_alpha:
-  add al, 'A'-10
-itao16_store_loop_stosb:
-  stosb
-  loop itoa16_store_loop
-  xor al,al
-  stosb     # null terminated string
-  mov eax, ebx
-  pop ebx
-  pop ebp
-  ret
-ASM_END(itoa16)
+#   mov ebx, [ebp + 12+4]   # str ptr
+#   mov edi, ebx
+
+# itoa16_store_loop:
+#   # 1 digits is always guaranteed: 0
+#   pop ax
+#   mov al, ah
+#   cmp al, 9
+#   jg itoa16_store_loop_alpha
+#   add al, '0'
+#   jmp itao16_store_loop_stosb
+# itoa16_store_loop_alpha:
+#   add al, 'A'-10
+# itao16_store_loop_stosb:
+#   stosb
+#   loop itoa16_store_loop
+#   xor al,al
+#   stosb     # null terminated string
+#   mov eax, ebx
+#   pop ebx
+#   pop ebp
+#   ret
+# ASM_END(itoa16)

--- a/kernel/src/kernel.c
+++ b/kernel/src/kernel.c
@@ -198,5 +198,7 @@ noreturn void main()
     // intptr_t* t = (intptr_t*)0xFFFFFFFF;
     // *t=0;
 
-    for(;;);
+    for(;;) {
+        __asm__("hlt");
+    }
 }

--- a/kernel/src/lib/stdlib.h
+++ b/kernel/src/lib/stdlib.h
@@ -10,7 +10,7 @@
 // int atoi(const char * str);
 
 // TODO generalize in itoa taking a base
-char* itoa10(uint16_t value, char* str);
-char* itoa16(uint16_t value, char* str);
+// char* itoa10(uint16_t value, char* str);
+// char* itoa16(uint16_t value, char* str);
 
 char* itoa(unsigned int value, char* str, const uint8_t base);


### PR DESCRIPTION
- Kernel idle and remove faulty itoa10/16 functions
- bootloader fix itoa using div 16 bits instead of 8 bits
