### PR TITLE
Multiple makefile targets (DEBUG default) | Fix: itoa, tot_mem [bootloader]; PMM init (release)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,10 +4,13 @@ on: [push]
 
 jobs:
   ubuntu-build:
+    strategy:
+      matrix:
+        BUILD_TYPE: ['', 'debug', 'release', 'reldbg']
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v2.0.0
     - run: sudo apt-get -y install mtools
     - run: gcc -v
-    - run: make all
+    - run: make BUILD_TYPE=${{ matrix.BUILD_TYPE }} clean all

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,11 +6,11 @@ jobs:
   ubuntu-build:
     strategy:
       matrix:
-        BUILD_TYPE: ['', 'debug', 'release', 'reldbg']
+        BUILD_TYPE: ['debug', 'release', 'reldbg']
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v2.0.0
     - run: sudo apt-get -y install mtools
     - run: gcc -v
-    - run: make BUILD_TYPE="${{ matrix.BUILD_TYPE }}" clean all
+    - run: make BUILD_TYPE=${{ matrix.BUILD_TYPE }} clean all

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,4 +13,4 @@ jobs:
       uses: actions/checkout@v2.0.0
     - run: sudo apt-get -y install mtools
     - run: gcc -v
-    - run: make BUILD_TYPE=${{ matrix.BUILD_TYPE }} clean all
+    - run: make BUILD_TYPE="${{ matrix.BUILD_TYPE }}" clean all

--- a/BIOS_bootloader/src/bios/PrintNumber.inc
+++ b/BIOS_bootloader/src/bios/PrintNumber.inc
@@ -22,6 +22,7 @@ PrintNumber_loop:
   div bx        # DX:AX / 10 => AX = Quotient, DX= Remainder
   push dx
   inc cx
+  test ax,ax    # if zero...
   jnz PrintNumber_loop
 PrintNumber_loop_print:
   # 1 digits is always guaranteed: 0

--- a/BIOS_bootloader/src/boot2.asm
+++ b/BIOS_bootloader/src/boot2.asm
@@ -31,6 +31,7 @@ DrvNum:           .byte  0
 main:
   # in AL has been passed the DrvNum, storing it
   mov DrvNum, al
+  # in the stack there is the tot low memory
   # Loading Kernel...
   
   # 1. read FAT Root Dir
@@ -40,7 +41,7 @@ main:
   call LoadRootDirectory
   lea si, ok_msg
   call PrintStringNewLine
-  
+
   # 2. find kernel file
   lea si, find_kernel_file_msg
   call PrintStringDots
@@ -92,6 +93,9 @@ load_fat:
   mov eax, 0x12345678           # begin_marker
   stosd
   call GetTotalMemorySize
+  xor edx,edx
+  pop dx                        # lower mem from 1st stage
+  add eax, edx
   stosd
   mov al, DrvNum                # boot_device
   stosb

--- a/BIOS_bootloader/src/floppy.asm
+++ b/BIOS_bootloader/src/floppy.asm
@@ -78,7 +78,7 @@ main_relocated:
   lea  si, banner_msg
   call PrintString
 
-# Display Total Low Memory (it can be removed as it is not useful)
+# Get & Display Total Low Memory
   lea si, mem_msg
   call PrintString
   call GetMemorySize

--- a/BIOS_bootloader/src/floppy.asm
+++ b/BIOS_bootloader/src/floppy.asm
@@ -82,6 +82,7 @@ main_relocated:
   lea si, mem_msg
   call PrintString
   call GetMemorySize
+  push ax               # store for later
   call PrintNumber
   lea si, kb_unit_msg
   call PrintStringNewLine
@@ -101,13 +102,14 @@ main_relocated:
   dec al                    # removing sector 0
   mov ch, 0                 # Cylinder 0
   mov dh, 0                 # Head 0
-  mov cl, 2                 # 2nd sector, 1 is boot sector (this one), next one is the 1st reserved sector
+  mov cl, 2                 # 2nd sector, 1 is boot sector (this one), next one is the 2nd reserved sector
   call DriveReadSectors
   lea si, ok_msg
   call PrintStringNewLine
 
   xor ax, ax
   mov al, DrvNum
+#   pop dx                    # memory in KB
   jmp BOOT2_SEG
 
   # End of loader, shouldn't reach here

--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,13 @@ export BUILD_TYPE := debug
 # using make's computed variables to select object and bin folders
 # depending on the build type
 BUILD_DIR.debug=build/debug
-BUILD_DIR.release=build/release
 BIN_DIR.debug=bin/debug
+# release
+BUILD_DIR.release=build/release
 BIN_DIR.release=bin/release
+# releae with debug info
+BUILD_DIR.reldbg=build/reldbg
+BIN_DIR.reldbg=bin/reldbg
 
 export BUILD_DIR=$(BUILD_DIR.$(BUILD_TYPE))
 export BIN_DIR=$(BIN_DIR.$(BUILD_TYPE))

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ gdb-kernel-debug:
 		-ex 'layout reg' \
 		-ex 'break _start' \
 		-ex 'break *0x7c00' \
+		-ex 'b ${KERNEL_DIR}/src/kernel.c:100' \
 		-ex 'b ${KERNEL_DIR}/src/arch/x86/mmu/VMM.c:74' \
 		-ex 'set disassembly-flavor intel' \
 		-ex 'continue'

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,19 @@ export CC=gcc
 export AS=as
 export LD=ld
 
-export BUILD_DIR=build
-export BIN_DIR=bin
+# override with `make BUILD=release`
+# default to debug build
+export BUILD_TYPE := debug
+
+# using make's computed variables to select object and bin folders
+# depending on the build type
+BUILD_DIR.debug=build/debug
+BUILD_DIR.release=build/release
+BIN_DIR.debug=bin/debug
+BIN_DIR.release=bin/release
+
+export BUILD_DIR=$(BUILD_DIR.$(BUILD_TYPE))
+export BIN_DIR=$(BIN_DIR.$(BUILD_TYPE))
 
 export KERNEL_SEG=0x1000
 export KERNEL_FILENAME="BROSKRNL.SYS"
@@ -17,6 +28,11 @@ KERNEL_DIR=kernel
 .PHONY: kernel
 
 all: image
+
+t:
+	echo $(BUILD_TYPE)
+	echo $(BUILD_DIR)
+	echo $(BIN_DIR)
 
 bios_bootloader:
 	+$(MAKE) -C ${BIOS_BL_DIR} all

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,8 @@ gdb-kernel-debug:
 		-ex 'layout reg' \
 		-ex 'break _start' \
 		-ex 'break *0x7c00' \
-		-ex 'b ${KERNEL_DIR}/src/kernel.c:100' \
+		-ex 'b ${KERNEL_DIR}/src/kernel.c:102' \
+		-ex 'b ${KERNEL_DIR}/src/kernel.c:121' \
 		-ex 'b ${KERNEL_DIR}/src/arch/x86/mmu/VMM.c:74' \
 		-ex 'set disassembly-flavor intel' \
 		-ex 'continue'

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ The first section of the boot-loader is passing the boot drive number in `AL` re
 
 So when jumping to the 2nd stage, that information is passed on through a CPU Register (`AL`).
 
+It also passes the total low memory in KB as the first value in the stack.
+
 ---
 
 The 2nd stage is searching the Kernel file in the FAT12 filesystem and loading it at `0x1000`.

--- a/README.md
+++ b/README.md
@@ -152,6 +152,14 @@ for now a simple 1st 4MB identity paging. no real management happening yet
 
 > TODO, replace the bootloader stack with the "kernel stack"
 
+### Filesystem
+
+> TODO
+
+### Network
+
+> TODO
+
 ### Drivers
 
 > TODO

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -41,9 +41,9 @@ CFLAGS+=-lgcc
 CFLAGS+=-DKERNEL_SEG=${KERNEL_SEG}
 CFLAGS+=-fno-PIE # Github CI flags
 
-CFLAGS.debug+=-g
-CFLAGS.release+=-O2
-CFLAGS.reldbg=$(CFLAGS.debug) $(CFLAGS.release)
+CFLAGS.debug+=-g -DDEBUG
+CFLAGS.release+=-O2 -DNDEBUG
+CFLAGS.reldbg=-g $(CFLAGS.release)
 
 CFLAGS+=$(CFLAGS.$(BUILD_TYPE))
 

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -43,6 +43,7 @@ CFLAGS+=-fno-PIE # Github CI flags
 
 CFLAGS.debug+=-g
 CFLAGS.release+=-O2
+CFLAGS.reldbg=$(CFLAGS.debug) $(CFLAGS.release)
 
 CFLAGS+=$(CFLAGS.$(BUILD_TYPE))
 

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -32,7 +32,7 @@ INCLUDE_DIR=${SRC_DIR}
 CFLAGS+=-Wall -Werror #-Wmissing-prototypes
 CFLAGS+=-masm=intel
 # CFLAGS+=-O2	# optimization are creating issues on the code
-CFLAGS+=-g
+# CFLAGS+=-pedantic
 CFLAGS+=-std=c17
 CFLAGS+=-m32 -c -ffreestanding -I ${INCLUDE_DIR}
 # CFLAGS+= -MMD -MF
@@ -40,6 +40,12 @@ CFLAGS+=-nostartfiles -nostdlib
 CFLAGS+=-lgcc
 CFLAGS+=-DKERNEL_SEG=${KERNEL_SEG}
 CFLAGS+=-fno-PIE # Github CI flags
+
+CFLAGS.debug+=-g
+CFLAGS.release+=-O2
+
+CFLAGS+=$(CFLAGS.$(BUILD_TYPE))
+
 
 LFLAGS+=-m elf_i386 # change when starting the kernel in long mode
 LFLAGS+=-nostdlib --nmagic

--- a/kernel/kernel.ld
+++ b/kernel/kernel.ld
@@ -13,11 +13,11 @@ SECTIONS
         __code_main = .;
         *(.text.main)
         *(.text)
-        *(.rodata)
         . = ALIGN(PAGE_SIZE);
     }
     .data : {
         /* data = .; */
+        *(.rodata)
         *(.data)
         . = ALIGN(PAGE_SIZE);
     }

--- a/kernel/kernel.ld
+++ b/kernel/kernel.ld
@@ -6,11 +6,11 @@ STACK_SIZE = PAGE_SIZE * 1;
 SECTIONS
 {
     .text KERNEL_SEG : {
-        __code_start = .;
+        /* __code_start = .; */
         *(.text._start)
         *(.text._start_entry)
         *(.text._start_failure)
-        __code_main = .;
+        /* __code_main = .; */
         *(.text.main)
         *(.text)
         . = ALIGN(PAGE_SIZE);
@@ -31,5 +31,5 @@ SECTIONS
         . = ALIGN(PAGE_SIZE);
     }
     __end = .;
-    __size = __end - (__code_main);
+    /* __size = __end - (__code_main); */
 }

--- a/kernel/src/arch/x86/mmu/PMM.c
+++ b/kernel/src/arch/x86/mmu/PMM.c
@@ -14,7 +14,6 @@ static uint32_t     _PMM_used_blocks    = 0;
 static bitset32_t   _PMM_mem_map        = NULL;
 static uint32_t     _PMM_mem_map_size   = 0;
 
-
 static inline size_t _size2block(const size_t size)
 {
     return (size / PMM_BLOCK_SIZE) + ((size % PMM_BLOCK_SIZE) ? 1 : 0);
@@ -65,8 +64,7 @@ void PMM_MemMap_deinit_kernel()
     extern uint32_t __size;
     extern uint32_t __code_start;
 
-    // TODO: add also something for the stack! (at the moment is defined in kernel.ld)
-
+    // TODO: add also something for the stack!
     PMM_MemMap_deinit((uint32_t)&__code_start, ((uint32_t) &__size) + _PMM_mem_map_size);
 }
 

--- a/kernel/src/arch/x86/mmu/PMM.c
+++ b/kernel/src/arch/x86/mmu/PMM.c
@@ -59,13 +59,13 @@ void PMM_MemMap_deinit(const paddr_t physical_addr, const uint32_t size)
     // TODO assert used blocks <= max blocks
 }
 
-void PMM_MemMap_deinit_kernel()
+void PMM_MemMap_deinit_kernel(const uint32_t code_start, const uint32_t code_size)
 {
-    extern uint32_t __size;
-    extern uint32_t __code_start;
+    // extern uint32_t __size;
+    // extern uint32_t __code_start;
 
     // TODO: add also something for the stack!
-    PMM_MemMap_deinit((uint32_t)&__code_start, ((uint32_t) &__size) + _PMM_mem_map_size);
+    PMM_MemMap_deinit(code_start, code_size + _PMM_mem_map_size);
 }
 
 inline int PMM_Blocks_used()

--- a/kernel/src/arch/x86/mmu/PMM.c
+++ b/kernel/src/arch/x86/mmu/PMM.c
@@ -70,12 +70,12 @@ void PMM_MemMap_deinit_kernel()
     PMM_MemMap_deinit((uint32_t)&__code_start, ((uint32_t) &__size) + _PMM_mem_map_size);
 }
 
-inline uint32_t PMM_Blocks_used()
+inline int PMM_Blocks_used()
 {
     return _PMM_used_blocks;
 }
 
-inline uint32_t PMM_Blocks_free()
+inline int PMM_Blocks_free()
 {
     return _PMM_max_blocks - _PMM_used_blocks;
 }

--- a/kernel/src/arch/x86/mmu/PMM.h
+++ b/kernel/src/arch/x86/mmu/PMM.h
@@ -24,7 +24,7 @@ void PMM_MemMap_deinit(const paddr_t physical_addr, const uint32_t size);
 /*
  * Mark the kernel memory as in use
  */
-void PMM_MemMap_deinit_kernel();
+void PMM_MemMap_deinit_kernel(const uint32_t code_start, const uint32_t code_size);
 
 int PMM_Blocks_used();
 int PMM_Blocks_free();

--- a/kernel/src/arch/x86/mmu/PMM.h
+++ b/kernel/src/arch/x86/mmu/PMM.h
@@ -21,8 +21,11 @@ void PMM_init(const uint32_t tot_mem_KB, paddr_t physical_mem_start);
 void PMM_MemMap_init(const paddr_t physical_addr, const uint32_t size);
 void PMM_MemMap_deinit(const paddr_t physical_addr, const uint32_t size);
 
+/*
+ * Mark the kernel memory as in use
+ */
 void PMM_MemMap_deinit_kernel();
-// readonly
+
 int PMM_Blocks_used();
 int PMM_Blocks_free();
 

--- a/kernel/src/arch/x86/mmu/PMM.h
+++ b/kernel/src/arch/x86/mmu/PMM.h
@@ -23,8 +23,8 @@ void PMM_MemMap_deinit(const paddr_t physical_addr, const uint32_t size);
 
 void PMM_MemMap_deinit_kernel();
 // readonly
-uint32_t PMM_Blocks_used();
-uint32_t PMM_Blocks_free();
+int PMM_Blocks_used();
+int PMM_Blocks_free();
 
 void *PMM_malloc_blocks(const size_t num_blocks);
 void PMM_free_blocks(void* ptr, const size_t num_blocks);

--- a/kernel/src/arch/x86/mmu/VMM.c
+++ b/kernel/src/arch/x86/mmu/VMM.c
@@ -86,8 +86,7 @@ bool VMM_init()
     memset(_kernel_directory, 0, sizeof(page_directory_t));
     memset(page_table, 0, sizeof(page_table_t));
 
-    // TODO: forgot to allocate some space for the stack ...
-    //       it is just defined inside the linker at the moment
+    // TODO: need to allocate some space for the stack too somewhere...
 
     // first 1MB, identity
     for (uint32_t i = 0; i < PAGE_TABLE_ENTRIES; i++)
@@ -98,7 +97,9 @@ bool VMM_init()
     _kernel_directory->entries[0] = (PDE_t) page_table | PDE_PRESENT | PDE_WRITABLE;
 
     ISR_register_interrupt_handler(INT_Page_Fault, page_fault_handler);
-    VMM_switch_page_directory(_kernel_directory);
+    if (!VMM_switch_page_directory(_kernel_directory))
+        return false;
+
     VMM_enable_paging();
 
     return true;

--- a/kernel/src/arch/x86/mmu/VMM.c
+++ b/kernel/src/arch/x86/mmu/VMM.c
@@ -77,7 +77,7 @@ bool VMM_init()
     // TODO pass MemMap informations
 
     _kernel_directory = PMM_malloc(sizeof(page_directory_t));
-    
+
     page_table_t* page_table  = PMM_malloc(sizeof(page_table_t));
 
     if(page_table == NULL || _kernel_directory == NULL)

--- a/kernel/src/arch/x86/mmu/VMM.h
+++ b/kernel/src/arch/x86/mmu/VMM.h
@@ -75,8 +75,6 @@ typedef struct page_directory_t
 } page_directory_t;
 _Static_assert(sizeof(page_directory_t) == PAGE_DIR_ENTRIES * sizeof(uint32_t));
 
-
-
 bool VMM_init();
 bool VMM_switch_page_directory(page_directory_t* page_directory);
 void VMM_enable_paging();

--- a/kernel/src/kernel.c
+++ b/kernel/src/kernel.c
@@ -54,15 +54,16 @@ __attribute__((section(".text._start_entry"))) noreturn void _start_entry()
     const uint32_t* _startPtr = (uint32_t*)&_start;
     // self-relocating kernel checks
     extern uint32_t __end;
-    extern const uint32_t __size;
-    // TODO: with optimization there is a difference...
-    const uint32_t kernel_size = (uint32_t)&__end - (uint32_t)(&main);
+    // extern const uint32_t __size;
+    // NOTE: with optimization there is a difference about alignment
+    // const uint32_t kernel_size = (uint32_t)&__end - (uint32_t)(&main);
+    
 
     if(_eax != __BROS
         || _sys_info->begin_marker != SYS_INFO_BEGIN
         || *_sys_info_end_marker != SYS_INFO_END
         || _startPtr != KERNEL_ADDR
-        || kernel_size != (uint32_t)&__size
+        // || kernel_size != (uint32_t)&__size
         || (uint32_t)&main <= (uint32_t)&_start_failure
         || (uint32_t)&main <= (uint32_t)&_start)
     {

--- a/kernel/src/kernel.c
+++ b/kernel/src/kernel.c
@@ -115,8 +115,7 @@ __attribute__((section(".text._start_entry"))) noreturn void _start_entry()
         con_col_t old_col = CON_getConsoleColor();
         CON_setConsoleColor2(VGA_COLOR_RED, VGA_COLOR_BRIGHT_CYAN);
         volatile boot_MEM_MAP_Info_Entry_t* mem_map = MEM_MAP_ENTRY_PTR(_sys_info);
-        
-        for(int i = 0; i < (int)_sys_info->num_mem_map_entries; i++)
+        for(int i = 0; i < _sys_info->num_mem_map_entries; i++)
         {
             CON_printf("test");
             const char* mem_types[] = {

--- a/kernel/src/kernel.c
+++ b/kernel/src/kernel.c
@@ -117,7 +117,6 @@ __attribute__((section(".text._start_entry"))) noreturn void _start_entry()
         volatile boot_MEM_MAP_Info_Entry_t* mem_map = MEM_MAP_ENTRY_PTR(_sys_info);
         for(int i = 0; i < _sys_info->num_mem_map_entries; i++)
         {
-            CON_printf("test");
             const char* mem_types[] = {
                 "Available",
                 "Reserved",


### PR DESCRIPTION
- fix bootloader itoa
- pass tot low memory to 2nd stage bootloader trhough the stack
- makefile for targets: debug (default), release, reldbg
