### PR TITLE
Fix macro definition for global assembly symbol

### DIFF
--- a/kernel/src/arch/x86/defs/asm.h
+++ b/kernel/src/arch/x86/defs/asm.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #define ASM_BEGIN(x) \
-    .globl x; \
+    .global x; \
     x:
 
 #define ASM_END(x) \


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized the assembler directive used to declare global symbols to improve compatibility across different toolchains.
  * This maintenance update aims to reduce build inconsistencies across environments.
  * No functional or behavioral changes; runtime performance and features remain unaffected.
  * End users should not notice any differences; this is purely an internal compatibility refinement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->